### PR TITLE
Add support for adding separators to visible items only

### DIFF
--- a/StackViewSeparator/Classes/UIStackView+Extension.swift
+++ b/StackViewSeparator/Classes/UIStackView+Extension.swift
@@ -52,9 +52,17 @@ extension UIStackView {
             layoutSubviews()
         }
     }
-    
+
+    /// Adds separator view for each visible arranged subview. Call this function after updating your stack view items.
     open func addSeparators() {
-        for _ in 1..<arrangedSubviews.count {
+        // Remove all separators.
+        separatorViews.forEach({ $0.removeFromSuperview() })
+        separatorViews = []
+
+        // Add separtors for each visible item.
+        let visibleItems = arrangedSubviews.filter({ $0.isHidden == false })
+        guard visibleItems.count > 1 else { return }
+        for _ in 1..<visibleItems.count {
             let separatorView = UIView()
             separatorView.backgroundColor = separatorColor
             separatorViews.append(separatorView)


### PR DESCRIPTION
This PR updates `addSeparators()` function and adds separator only for visible `arrangedSubviews`.
Also, it removes all currently added separators before the separator adding process.
A new pod version would be appreciated.

Teşekkürler! :) 